### PR TITLE
Added ProgressMeter functionality [Experimental/RFC]

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The adaptive solvers accept the following keywords
 - `maxstep`, `minstep` and `initstep`: determine the maximal, minimal and initial integration step (defaults `minstep=|tspan[end] - tspan[1]|/1e9`, `maxstep=|tspan[end] - tspan[1]|/2.5` and automatic initial step estimation).
 - `points=:all` (default): output is given for each value in `tspan` as well as for each intermediate point the solver used.
 - `points=:specified`: output is given only for each value in `tspan`.
+- `progressmeter = false` (default): if true, a progress meter of how much of the time span has been solved already will be displayed while the ODE solver is running 
 
 Additionally, `ode23s` solver supports
 - `jacobian = G(t,y)`: user-supplied Jacobian G(t,y) = dF(t,y)/dy (default estimate by finite-difference method).

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5-
 Polynomials
 ForwardDiff
 Compat 0.4.1
+ProgressMeter

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -22,6 +22,7 @@ using Polynomials
 using Compat
 import Compat.String
 using ForwardDiff
+using ProgressMeter
 
 import Base: start, next, done, collect, show, convert
 

--- a/src/options.jl
+++ b/src/options.jl
@@ -16,6 +16,7 @@ General:
 - norm          function to calculate the norm in step control
 - maxiters ::T  maximum number of steps
 - isoutofdomain::Function checks if the solution is outside of the allowed domain
+- progressmeter ::Bool display progressmeter
 
 """
 immutable AdaptiveOptions{T,N<:Function,O<:Function} <: Options{T}
@@ -28,6 +29,7 @@ immutable AdaptiveOptions{T,N<:Function,O<:Function} <: Options{T}
     norm::N
     maxiters::T
     isoutofdomain::O
+    progressmeter ::Bool
 end
 
 @compat function (::Type{AdaptiveOptions{T}}){T,N,O}(;
@@ -41,9 +43,10 @@ end
                                                      norm::N  = y->maxabs(y),
                                                      maxiters = T(1//0),
                                                      isoutofdomain::O = Base.isnan,
+                                                     progressmeter = false,
                                                      kargs...)
     @assert minstep>=T(0) && maxstep>=T(0) && initstep>=T(0) # TODO: move to inner constructor
-    AdaptiveOptions{T,N,O}(tstop,reltol,abstol,minstep,maxstep,initstep,norm,maxiters,isoutofdomain)
+    AdaptiveOptions{T,N,O}(tstop,reltol,abstol,minstep,maxstep,initstep,norm,maxiters,isoutofdomain,progressmeter)
 end
 
 """
@@ -55,20 +58,23 @@ General:
 
 - initstep ::T  initial step (always positive)
 - tstop    ::T  end integration time
+- progressmeter ::Bool display progressmeter
 
 """
 immutable FixedOptions{T} <: Options{T}
     tstop::T
     initstep::T
+    progressmeter ::Bool
 end
 
 @compat function (::Type{FixedOptions{T}}){T}(;
                                               tout     = [T(1//0)],
                                               tstop    = tout[end],
                                               initstep = T(1//100),
+                                              progressmeter = false,
                                               kargs...)
     @assert initstep>=0
-    FixedOptions{T}(tstop,initstep)
+    FixedOptions{T}(tstop,initstep,progressmeter)
 end
 
 function show{T}(io::IO, opts :: Options{T})

--- a/src/top-interface.jl
+++ b/src/top-interface.jl
@@ -36,7 +36,7 @@ function ode{T,Y,M<:AbstractSolver}(F, y0::Y,
 
     if !prob.solver.opts.progressmeter
         for (t,y) in prob
-            (to,t)
+            push!(to,t)
             push!(yo, extract ? y[1] : copy(y))
         end
     else
@@ -46,7 +46,7 @@ function ode{T,Y,M<:AbstractSolver}(F, y0::Y,
         prog = Progress(round(Int,1000*tdir*(tf-t0)), "Solving:")
 
         for (t,y) in prob
-          (to,t)
+          push!(to,t)
           push!(yo, extract ? y[1] : copy(y))
           prog.counter = max(1,round(Int,1000.0*tdir*(t-t0)))
           ProgressMeter.updateProgress!(prog; showvalues = [(:current_t,t),(:final_t,prob.solver.opts.tstop)])

--- a/src/top-interface.jl
+++ b/src/top-interface.jl
@@ -33,11 +33,25 @@ function ode{T,Y,M<:AbstractSolver}(F, y0::Y,
 
     to = Array(T,0)
     yo = Array(Y,0)
-    for (t,y) in prob
-        push!(to,t)
-        push!(yo, extract ? y[1] : copy(y))
-    end
 
+    if !prob.solver.opts.progressmeter
+        for (t,y) in prob
+            (to,t)
+            push!(yo, extract ? y[1] : copy(y))
+        end
+    else
+        t0 = prob.ivp.t0
+        tf = prob.solver.opts.tstop
+        tdir = sign(tf-t0)
+        prog = Progress(round(Int,1000*tdir*(tf-t0)), "Solving:")
+
+        for (t,y) in prob
+          (to,t)
+          push!(yo, extract ? y[1] : copy(y))
+          prog.counter = max(1,round(Int,1000.0*tdir*(t-t0)))
+          ProgressMeter.updateProgress!(prog; showvalues = [(:current_t,t),(:final_t,prob.solver.opts.tstop)])
+        end
+    end
     return (to,yo)
 end
 


### PR DESCRIPTION
This is a small PR (which may be more of a proof of concept than anything else) in which Tim Holy's ProgressMeter package is used to show how much of a ODE problem a solver has already solved.

I found that the iterator formulation of ODE.jl allowed for very easy integration of the ProgressMeter package. All of the code is implemented at the top level interface, using the iteration loop over the `iterate` object that is created for the solver and problem combination. In order to enable the progress meter on a given run, I added a new keyword agrument to the fixed and adaptive solver options called `progressmeter`. When set to `true`, a bar showing how far along the time span the solver has already solved for is displayed. It is set to `false` as a default. Below is a screenshot of it all in action:
![ode iterator progressmeter screen shot](https://cloud.githubusercontent.com/assets/12954944/18395154/43834d70-768b-11e6-9066-333e336ec81a.png)

Here is the script run in the above screenshot. 

```
using ODE;
function f(t, y)
   # Extract the components of the y vector
   (x, v) = y
   # Our system of differential equations
   x_prime = v
   v_prime = -x
   # Return the derivatives as a vector
   [x_prime; v_prime]
end;
time = 0:0.001:40000;
starty = [0.0; 0.1];
t,y = ODE.ode23(f,starty,time,progressmeter=true);
```

Also a cool upshot of this is, because the ODE solvers do have a somewhat uniform running time, the predicted "ETA" does give an appropriate estimate. 

All of this is just one of the many pluses for a general iterator framework!

Thanks a million to @mauro3 for the idea and thoughts for how to get started. 
